### PR TITLE
画面サイズが小さいときにヘッダーに隠れていたナビゲーションを利用できるように変更

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -15,6 +15,9 @@ export namespace Components {
     }
     interface AppHome {
     }
+    interface AppNavMobile {
+        "show": boolean;
+    }
     interface AppRoot {
     }
     interface ProductCard {
@@ -46,6 +49,12 @@ declare global {
         prototype: HTMLAppHomeElement;
         new (): HTMLAppHomeElement;
     };
+    interface HTMLAppNavMobileElement extends Components.AppNavMobile, HTMLStencilElement {
+    }
+    var HTMLAppNavMobileElement: {
+        prototype: HTMLAppNavMobileElement;
+        new (): HTMLAppNavMobileElement;
+    };
     interface HTMLAppRootElement extends Components.AppRoot, HTMLStencilElement {
     }
     var HTMLAppRootElement: {
@@ -63,6 +72,7 @@ declare global {
         "app-footer": HTMLAppFooterElement;
         "app-header": HTMLAppHeaderElement;
         "app-home": HTMLAppHomeElement;
+        "app-nav-mobile": HTMLAppNavMobileElement;
         "app-root": HTMLAppRootElement;
         "product-card": HTMLProductCardElement;
     }
@@ -76,6 +86,9 @@ declare namespace LocalJSX {
     }
     interface AppHome {
     }
+    interface AppNavMobile {
+        "show"?: boolean;
+    }
     interface AppRoot {
     }
     interface ProductCard {
@@ -86,6 +99,7 @@ declare namespace LocalJSX {
         "app-footer": AppFooter;
         "app-header": AppHeader;
         "app-home": AppHome;
+        "app-nav-mobile": AppNavMobile;
         "app-root": AppRoot;
         "product-card": ProductCard;
     }
@@ -98,6 +112,7 @@ declare module "@stencil/core" {
             "app-footer": LocalJSX.AppFooter & JSXBase.HTMLAttributes<HTMLAppFooterElement>;
             "app-header": LocalJSX.AppHeader & JSXBase.HTMLAttributes<HTMLAppHeaderElement>;
             "app-home": LocalJSX.AppHome & JSXBase.HTMLAttributes<HTMLAppHomeElement>;
+            "app-nav-mobile": LocalJSX.AppNavMobile & JSXBase.HTMLAttributes<HTMLAppNavMobileElement>;
             "app-root": LocalJSX.AppRoot & JSXBase.HTMLAttributes<HTMLAppRootElement>;
             "product-card": LocalJSX.ProductCard & JSXBase.HTMLAttributes<HTMLProductCardElement>;
         }

--- a/src/components/app-header/app-header.scss
+++ b/src/components/app-header/app-header.scss
@@ -1,6 +1,6 @@
 :host {
   display: block;
-  ion-header > ion-toolbar > ion-buttons[slot=end] {
+  ion-header > ion-toolbar > ion-buttons[slot="end"] {
     @media (max-width: 575.98px) {
       display: none !important;
     }
@@ -10,5 +10,11 @@
     font-size: inherit;
     margin: inherit;
     padding: inherit;
+  }
+  .dom-hide {
+    display: none;
+  }
+  .dom-show {
+    display: block;
   }
 }

--- a/src/components/app-header/app-header.scss
+++ b/src/components/app-header/app-header.scss
@@ -11,10 +11,14 @@
     margin: inherit;
     padding: inherit;
   }
+  .default-hide {
+    display: none;
+  }
   .dom-hide {
     display: none;
   }
+  ion-header > ion-toolbar > ion-buttons[slot="end"],
   .dom-show {
-    display: block;
+    display: block !important;
   }
 }

--- a/src/components/app-header/app-header.tsx
+++ b/src/components/app-header/app-header.tsx
@@ -6,11 +6,25 @@ import { Component, Host, h, State } from "@stencil/core";
   shadow: true
 })
 export class AppHeader {
+  /**
+   * スマホ用のナビゲーションの表示切り替え
+   */
   @State() mobileNav: boolean = false;
+
+  /**
+   * ナビゲーションのモード切替
+   */
+  @State() mode: "short";
 
   private toggleMobileNav = () => {
     this.mobileNav = !this.mobileNav;
   };
+
+  componentDidLoad() {
+    if (document.body.offsetWidth < 690) {
+      this.mode = "short";
+    }
+  }
 
   render() {
     return (
@@ -22,30 +36,59 @@ export class AppHeader {
                 <ion-icon slot="start" name="logo-ionic" />
                 Ionic Japan
               </ion-button>
-              <ion-button href="https://ionicframework.jp/docs">
+              <ion-button
+                class={{
+                  "dom-hide": this.mode === "short" && true
+                }}
+                href="https://ionicframework.jp/docs"
+              >
                 <ion-icon name="library-outline" slot="start" />
                 日本語ドキュメンテーション
               </ion-button>
-              <ion-button href="/case">利用事例</ion-button>
+              <ion-button
+                class={{
+                  "dom-hide": this.mode === "short" && true
+                }}
+                href="/case"
+              >
+                利用事例
+              </ion-button>
             </ion-buttons>
 
             <ion-buttons slot="end">
               <ion-button
+                class={{
+                  "dom-hide": this.mode === "short" && true
+                }}
                 href="https://github.com/ionic-jp/community-site"
                 target="_blank"
               >
                 <ion-icon slot="icon-only" name="logo-github" />
               </ion-button>
               <ion-button
+                class={{
+                  "dom-hide": this.mode === "short" && true
+                }}
                 href="https://twitter.com/ionic_japan"
                 target="_blank"
               >
                 <ion-icon slot="icon-only" name="logo-twitter" />
               </ion-button>
-              <ion-button href="https://ionic-jp.connpass.com/" target="_blank">
+              <ion-button
+                class={{
+                  "dom-hide": this.mode === "short" && true
+                }}
+                href="https://ionic-jp.connpass.com/"
+                target="_blank"
+              >
                 イベント
               </ion-button>
-              <ion-button onclick={this.toggleMobileNav}>
+              <ion-button
+                class={{
+                  "dom-show": this.mode === "short" && true
+                }}
+                onclick={this.toggleMobileNav}
+              >
                 <ion-icon name="ellipsis-vertical-outline" />
               </ion-button>
             </ion-buttons>

--- a/src/components/app-header/app-header.tsx
+++ b/src/components/app-header/app-header.tsx
@@ -21,7 +21,7 @@ export class AppHeader {
   };
 
   componentDidLoad() {
-    if (document.body.offsetWidth < 690) {
+    if (document.documentElement.clientWidth < 690) {
       this.mode = "short";
     }
   }
@@ -85,7 +85,8 @@ export class AppHeader {
               </ion-button>
               <ion-button
                 class={{
-                  "dom-show": this.mode === "short" && true
+                  "dom-show": this.mode === "short" && true,
+                  "default-hide": true
                 }}
                 onclick={this.toggleMobileNav}
               >

--- a/src/components/app-header/app-header.tsx
+++ b/src/components/app-header/app-header.tsx
@@ -1,11 +1,17 @@
-import { Component, Host, h } from '@stencil/core';
+import { Component, Host, h, State } from "@stencil/core";
 
 @Component({
-  tag: 'app-header',
-  styleUrl: 'app-header.scss',
-  shadow: true,
+  tag: "app-header",
+  styleUrl: "app-header.scss",
+  shadow: true
 })
 export class AppHeader {
+  @State() mobileNav: boolean = false;
+
+  private toggleMobileNav = () => {
+    this.mobileNav = !this.mobileNav;
+  };
+
   render() {
     return (
       <Host>
@@ -17,29 +23,36 @@ export class AppHeader {
                 Ionic Japan
               </ion-button>
               <ion-button href="https://ionicframework.jp/docs">
-                <ion-icon name="library-outline" slot="start"></ion-icon>
+                <ion-icon name="library-outline" slot="start" />
                 日本語ドキュメンテーション
               </ion-button>
-              <ion-button href="/case">
-                利用事例
-              </ion-button>
+              <ion-button href="/case">利用事例</ion-button>
             </ion-buttons>
 
             <ion-buttons slot="end">
-              <ion-button href="https://github.com/ionic-jp/community-site" target="_blank">
+              <ion-button
+                href="https://github.com/ionic-jp/community-site"
+                target="_blank"
+              >
                 <ion-icon slot="icon-only" name="logo-github" />
               </ion-button>
-              <ion-button href="https://twitter.com/ionic_japan" target="_blank">
+              <ion-button
+                href="https://twitter.com/ionic_japan"
+                target="_blank"
+              >
                 <ion-icon slot="icon-only" name="logo-twitter" />
               </ion-button>
               <ion-button href="https://ionic-jp.connpass.com/" target="_blank">
                 イベント
               </ion-button>
+              <ion-button onclick={this.toggleMobileNav}>
+                <ion-icon name="ellipsis-vertical-outline" />
+              </ion-button>
             </ion-buttons>
           </ion-toolbar>
+          <app-nav-mobile show={this.mobileNav} />
         </ion-header>
       </Host>
     );
   }
-
 }

--- a/src/components/app-nav-mobile/app-nav-mobile.scss
+++ b/src/components/app-nav-mobile/app-nav-mobile.scss
@@ -1,0 +1,6 @@
+:host {
+  display: none;
+}
+:host(.show) {
+  display: block;
+}

--- a/src/components/app-nav-mobile/app-nav-mobile.tsx
+++ b/src/components/app-nav-mobile/app-nav-mobile.tsx
@@ -1,0 +1,63 @@
+import { Component, Host, h, Prop } from "@stencil/core";
+
+@Component({
+  tag: "app-nav-mobile",
+  styleUrl: "app-nav-mobile.scss",
+  shadow: true
+})
+export class AppNavMobile {
+  @Prop() show: boolean;
+  techs = [
+    {
+      title: "日本語ドキュメーション",
+      icon: "library-outline",
+      url: "https://ionicframework.jp/docs",
+      target: "_self"
+    },
+    {
+      title: "利用事例",
+      icon: "albums-outline",
+      url: "/case",
+      target: "_self"
+    },
+    {
+      title: "Github",
+      icon: "logo-github",
+      url: "https://github.com/ionic-jp/community-site",
+      target: "_blank"
+    },
+    {
+      title: "Twitter",
+      icon: "logo-twitter",
+      url: "https://twitter.com/ionic_japan",
+      target: "_blank"
+    },
+    {
+      title: "イベント",
+      icon: "ticket-outline",
+      url: "https://ionic-jp.connpass.com/",
+      target: "_blank"
+    }
+  ];
+
+  render() {
+    return (
+      <Host
+        class={{
+          show: this.show
+        }}
+      >
+        <ion-list>
+          {this.techs.map(tech => (
+            <ion-item button href={tech.url} target={tech.target}>
+              <ion-icon slot="start" name={tech.icon} />
+              <ion-label>
+                <h3>{tech.title}</h3>
+              </ion-label>
+            </ion-item>
+          ))}
+        </ion-list>
+      </Host>
+    );
+  }
+}

--- a/src/components/app-nav-mobile/test/app-nav-mobile.e2e.ts
+++ b/src/components/app-nav-mobile/test/app-nav-mobile.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('app-nav-mobile', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<app-nav-mobile></app-nav-mobile>');
+
+    const element = await page.find('app-nav-mobile');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/src/components/app-nav-mobile/test/app-nav-mobile.e2e.ts
+++ b/src/components/app-nav-mobile/test/app-nav-mobile.e2e.ts
@@ -1,11 +1,11 @@
-import { newE2EPage } from '@stencil/core/testing';
+import { newE2EPage } from "@stencil/core/testing";
 
-describe('app-nav-mobile', () => {
-  it('renders', async () => {
+describe("app-nav-mobile", () => {
+  it("renders", async () => {
     const page = await newE2EPage();
-    await page.setContent('<app-nav-mobile></app-nav-mobile>');
+    await page.setContent("<app-nav-mobile></app-nav-mobile>");
 
-    const element = await page.find('app-nav-mobile');
-    expect(element).toHaveClass('hydrated');
+    const element = await page.find("app-nav-mobile");
+    expect(element).toHaveClass("hydrated");
   });
 });

--- a/src/components/app-nav-mobile/test/app-nav-mobile.spec.tsx
+++ b/src/components/app-nav-mobile/test/app-nav-mobile.spec.tsx
@@ -1,0 +1,18 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { AppNavMobile } from '../app-nav-mobile';
+
+describe('app-nav-mobile', () => {
+  it('renders', async () => {
+    const page = await newSpecPage({
+      components: [AppNavMobile],
+      html: `<app-nav-mobile></app-nav-mobile>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <app-nav-mobile>
+        <mock:shadow-root>
+          <slot></slot>
+        </mock:shadow-root>
+      </app-nav-mobile>
+    `);
+  });
+});


### PR DESCRIPTION

## 修正前

![](https://gyazo.com/200e56a631dd42419b58fe77c1ed3b0c.png)

## 修正後

https://user-images.githubusercontent.com/6760605/118288177-1b2cf480-b50f-11eb-9276-082d5de59be4.mp4

